### PR TITLE
Fixed NPE exception in Records generator

### DIFF
--- a/ac.soton.eventb.emf.record.generator/src/ac/soton/eventb/records/generator/rules/RecordRuleMachine.java
+++ b/ac.soton.eventb.emf.record.generator/src/ac/soton/eventb/records/generator/rules/RecordRuleMachine.java
@@ -76,7 +76,7 @@ public class RecordRuleMachine extends AbstractRule implements IRule {
 	    String recordName = r.getName();
 	    
 	    //var for record
-	    if (r.getSubsets()!=null & r.getSubsets().getName()!=r.getName()) {
+	    if (r.getSubsets()!=null && r.getSubsets().getName()!=r.getName()) {
 	    	String recordVarCmt = "record translation variable";
 	    	Variable recordVar = Make.variable(recordName, recordVarCmt);
 	    	varList.add(recordVar);


### PR DESCRIPTION
& (bitwise and) should be && (logical conjunction).
This closes Issue #9
